### PR TITLE
Add Firestore rules for warehouse collections

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,1 +1,28 @@
-{"flutter":{"platforms":{"android":{"default":{"projectId":"fws-dashboard","appId":"1:476401337046:android:26504ac0f4f556692bbf77","fileOutput":"android/app/google-services.json"}},"dart":{"lib/firebase_options.dart":{"projectId":"fws-dashboard","configurations":{"android":"1:476401337046:android:26504ac0f4f556692bbf77","ios":"1:476401337046:ios:061495436f999a322bbf77","macos":"1:476401337046:ios:ec9da6a9e412ea762bbf77","web":"1:476401337046:web:422a920bf1538f102bbf77","windows":"1:476401337046:web:a43c2ea419e0b6422bbf77"}}}}}}
+{
+  "flutter": {
+    "platforms": {
+      "android": {
+        "default": {
+          "projectId": "fws-dashboard",
+          "appId": "1:476401337046:android:26504ac0f4f556692bbf77",
+          "fileOutput": "android/app/google-services.json"
+        }
+      },
+      "dart": {
+        "lib/firebase_options.dart": {
+          "projectId": "fws-dashboard",
+          "configurations": {
+            "android": "1:476401337046:android:26504ac0f4f556692bbf77",
+            "ios": "1:476401337046:ios:061495436f999a322bbf77",
+            "macos": "1:476401337046:ios:ec9da6a9e412ea762bbf77",
+            "web": "1:476401337046:web:422a920bf1538f102bbf77",
+            "windows": "1:476401337046:web:a43c2ea419e0b6422bbf77"
+          }
+        }
+      }
+    }
+  },
+  "firestore": {
+    "rules": "firestore.rules"
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,17 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /projects/{project}/parts/{part} {
+      allow read, update: if request.auth != null;
+    }
+    match /bodegas/{bodega} {
+      allow read: if request.auth != null;
+    }
+    match /warehouse_stock/{doc} {
+      allow read, write: if request.auth != null;
+    }
+    match /warehouse_movements/{doc} {
+      allow create, read: if request.auth != null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- define Firestore rules for project parts, bodegas, warehouse stock and movements
- reference Firestore rules in firebase.json

## Testing
- `flutter analyze` *(fails: command not found)*
- `firebase deploy --only firestore:rules` *(fails: command not found)*
- `curl "https://firestore.googleapis.com/v1/projects/fws-dashboard/databases/(default)/documents/bodegas"` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c456649c64832aaa824b54020b18f4